### PR TITLE
Replace broken link to mattermost documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/NotSqrt/mattermost-integration-gitlab.svg?branch=master)](https://travis-ci.org/NotSqrt/mattermost-integration-gitlab)
 [![Coverage Status](https://coveralls.io/repos/NotSqrt/mattermost-integration-gitlab/badge.svg?branch=master&service=github)](https://coveralls.io/github/NotSqrt/mattermost-integration-gitlab?branch=master)
 
-This integrations service posts [issue](http://doc.gitlab.com/ee/web_hooks/web_hooks.html#issues-events), [comment](http://doc.gitlab.com/ee/web_hooks/web_hooks.html#comment-events) and [merge request](http://doc.gitlab.com/ee/web_hooks/web_hooks.html#merge-request-events) events from a GitLab repository into specific Mattermost channels by formatting output from [GitLab's outgoing webhooks](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/web_hooks/web_hooks.md) to [Mattermost's incoming webhooks](https://github.com/mattermost/platform/blob/master/doc/integrations/webhooks/Incoming-Webhooks.md).
+This integrations service posts [issue](http://doc.gitlab.com/ee/web_hooks/web_hooks.html#issues-events), [comment](http://doc.gitlab.com/ee/web_hooks/web_hooks.html#comment-events) and [merge request](http://doc.gitlab.com/ee/web_hooks/web_hooks.html#merge-request-events) events from a GitLab repository into specific Mattermost channels by formatting output from [GitLab's outgoing webhooks](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/doc/web_hooks/web_hooks.md) to [Mattermost's incoming webhooks](http://docs.mattermost.com/developer/webhooks-incoming.html).
 
 ## Project Goal
 


### PR DESCRIPTION
The link in the current readme.md was referring to the github repo of mattermost. They moved the docs form their git repo to their own docs.mattermost.com (see https://github.com/mattermost/platform/tree/master/doc/help).
