### PR TITLE
Show commit messages as links to commits.

### DIFF
--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -72,14 +72,17 @@ class PushEvent(BaseEvent):
         if self.data['total_commits_count'] > 1:
             description += "s"
 
-        return '%s pushed %s into the `%s` branch for project [%s](%s).' % (
+        text = '%s pushed %s into the `%s` branch for project [%s](%s).\n' % (
             self.data['user_name'],
             description,
             self.data['ref'],
             self.data['repository']['name'],
             self.data['repository']['homepage']
         )
-
+        for val in self.data['commits']:
+            text += "[%s](%s)" % (val['message'], val['url'])
+            
+        return text
 
 class IssueEvent(BaseEvent):
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/218612/17405757/0e7a04a2-5a61-11e6-89b5-2745bd5c2439.png)

As the image above shows, this patch will display the individual commit messages as links to the actual commit in Gitlab. Future improvements would typically be to only show the first line of the commit messages and add a run time argument to disable commit message output.
