### PR TITLE
Add a systemctl script example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Here's how to start:
     the integration service will listen on. We will refer to this address as the `https://<your-mattermost-integration-URL>`). You may change the IP:PORT with the adequate command-line options (see --help)
  8. You may want to add an upstart script to auto-start mattermost_gitlab at boot:
 
+### Using /etc/init script
+
 ```
 # /etc/init/mattermost-gitlab.conf
 start on runlevel [2345]
@@ -108,8 +110,9 @@ setuid mattermost
 exec /home/mattermost/ve/bin/mattermost_gitlab http://mattermost/hooks/hook-id
 ```
 
- Instead of `/etc/init/` script you may want to handle the mattermost_gitlab with supervisor (http://supervisord.org/). The
-    sample config file can be as simple as:
+### Using Supervisor
+
+ Instead of `/etc/init/` script you may want to handle the mattermost_gitlab with [supervisor](http://supervisord.org/). The sample config file can be as simple as:
 
 ```
 [program:mattermost-gitlab]
@@ -120,6 +123,8 @@ autorestart=true
 stdout_logfile=/home/mattermost/logs/mattermost_gitlab.log
 redirect_stderr=true
 ```
+
+### Using systemctl
 
 Another script using `systemctl`:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Here's how to start:
     the integration service will listen on. We will refer to this address as the `https://<your-mattermost-integration-URL>`). You may change the IP:PORT with the adequate command-line options (see --help)
  8. You may want to add an upstart script to auto-start mattermost_gitlab at boot:
 
-### Using /etc/init script
+### Using upstart script
 
 ```
 # /etc/init/mattermost-gitlab.conf

--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ stdout_logfile=/home/mattermost/logs/mattermost_gitlab.log
 redirect_stderr=true
 ```
 
+Another script using `systemctl`:
+
+```
+[Unit]
+Description=Mattermost gitlab integration
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=mattermost
+Group=mattermost
+ExecStart=/usr/local/bin/mattermost_gitlab http://mattermost/hooks/hook-id
+PrivateTmp=yes
+WorkingDirectory=/opt/mattermost
+Restart=always
+RestartSec=30
+LimitNOFILE=49152
+
+[Install]
+WantedBy=multi-user.target
+```
+
 3. **Connect your project to your GitLab account for outgoing webhooks**
  1. Log in to GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the left side of the project screen, click on **Settings** > **Web Hooks**. In the **URL** field enter `http://<your-mattermost-integration-URL>/new_event` (notice extra `new_event` URL argument). On this address the integration service will be receiving the events from your GitLab project. Make sure your URL has a leading `http://` or `https://`.
  2. On the same page, under **Trigger** select **Push events**, **Comment events**, **Issue events**, **Merge Request events**

--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ redirect_stderr=true
 
 Another script using `systemctl`:
 
+- sudo touch `/etc/systemd/system/mattermost_gitlab.service`
+- 'sudo vi /etc/systemd/system/mattermost_gitlab.service`
+- Copy the following lines into /etc/systemd/system/mattermost_gitlab.service
+
 ```
 [Unit]
 Description=Mattermost gitlab integration
@@ -142,6 +146,10 @@ LimitNOFILE=49152
 [Install]
 WantedBy=multi-user.target
 ```
+
+- `systemctl daemon-reload`
+- `systemctl enable mattermost`
+- `systemctl start mattermost`
 
 3. **Connect your project to your GitLab account for outgoing webhooks**
  1. Log in to GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the left side of the project screen, click on **Settings** > **Web Hooks**. In the **URL** field enter `http://<your-mattermost-integration-URL>/new_event` (notice extra `new_event` URL argument). On this address the integration service will be receiving the events from your GitLab project. Make sure your URL has a leading `http://` or `https://`.


### PR DESCRIPTION
This script is basically a copy-paste from the one provided here: https://docs.mattermost.com/install/prod-debian.html#set-up-mattermost-server

I'm not a `systemctl` expert but some option might not be mandatory (like `LimitNOFILE`).