### PR TITLE
Show commit messages as link to commits. (Take 2)

### DIFF
--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -82,7 +82,7 @@ class PushEvent(BaseEvent):
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
 
-        return text.encode('ascii')
+        return unicode(text)
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -72,14 +72,17 @@ class PushEvent(BaseEvent):
         if self.data['total_commits_count'] > 1:
             description += "s"
 
-        return '%s pushed %s into the `%s` branch for project [%s](%s).' % (
+        text = '%s pushed %s into the `%s` branch for project [%s](%s).\n' % (
             self.data['user_name'],
             description,
             self.data['ref'],
             self.data['repository']['name'],
             self.data['repository']['homepage']
         )
-
+        for val in self.data['commits']:
+            text += "[%s](%s)" % (val['message'], val['url'])
+            
+        return text
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -72,17 +72,22 @@ class PushEvent(BaseEvent):
         if self.data['total_commits_count'] > 1:
             description += "s"
 
-        text = '%s pushed %s into the `%s` branch for project [%s](%s).\n' % (
+        suffix = str('')
+        if len(self.data['commits']) > 0:
+            suffix = str('\n')
+
+        text = '%s pushed %s into the `%s` branch for project [%s](%s).%s' % (
             self.data['user_name'],
             description,
             self.data['ref'],
             self.data['repository']['name'],
-            self.data['repository']['homepage']
+            self.data['repository']['homepage'],
+            suffix
         )
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
 
-        return unicode(text)
+        return str(text)
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -82,7 +82,7 @@ class PushEvent(BaseEvent):
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
 
-        return str(text)
+        return text.encode('ascii')
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -81,8 +81,8 @@ class PushEvent(BaseEvent):
         )
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
-            
-        return text
+
+        return str(text)
 
 class IssueEvent(BaseEvent):
 

--- a/tests/data/gitlab/push/commit_dev_branch.md
+++ b/tests/data/gitlab/push/commit_dev_branch.md
@@ -1,1 +1,3 @@
 Example User pushed the first commit into the `refs/heads/dev` branch for project [example repository](http://gitlab_url/example_user/example-repository).
+[bump2
+](http://gitlab_url/example_user/example-repository/commit/a0e40a9b8e8bd3ad3acccf64c016244109b15d37)

--- a/tests/data/gitlab/push/commit_master_branch.md
+++ b/tests/data/gitlab/push/commit_master_branch.md
@@ -1,1 +1,3 @@
 Example User pushed 1 commit into the `refs/heads/master` branch for project [example repository](http://gitlab_url/example_user/example-repository).
+[bump
+](http://gitlab_url/example_user/example-repository/commit/bf249e058f87ef90a14be04268efde573c8431e4)

--- a/tests/data/gitlab/push/commit_merge_request.md
+++ b/tests/data/gitlab/push/commit_merge_request.md
@@ -1,1 +1,9 @@
 Example User pushed 2 commits into the `refs/heads/master` branch for project [example repository](http://gitlab_url/example_user/example-repository).
+[bump2
+](http://gitlab_url/example_user/example-repository/commit/a0e40a9b8e8bd3ad3acccf64c016244109b15d37)[Merge branch 'dev' into 'master'
+
+Master
+
+new description
+
+See merge request !1](http://gitlab_url/example_user/example-repository/commit/19df8c9c23daf53ea122ea0834814b846ea92875)


### PR DESCRIPTION
> ![alt text](https://cloud.githubusercontent.com/assets/218612/17405757/0e7a04a2-5a61-11e6-89b5-2745bd5c2439.png)
> As the image above shows, this patch will display the individual commit messages as links to the actual commit in Gitlab. Future improvements would typically be to only show the first line of the commit messages and add a run time argument to disable commit message output.

I wrapped return text with `str()` to convert the unicode string to a regular string. No idea if this is enough.