### PR TITLE
Update systemd readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ redirect_stderr=true
 
 Another script using `systemctl`:
 
-- sudo touch `/etc/systemd/system/mattermost_gitlab.service`
-- 'sudo vi /etc/systemd/system/mattermost_gitlab.service`
-- Copy the following lines into /etc/systemd/system/mattermost_gitlab.service
+- `sudo chown mattermost:mattermost /usr/local/bin/mattermost_gitlab` (optional)
+- `sudo nano /etc/systemd/system/mattermost_gitlab.service`
+- Copy the following lines into `/etc/systemd/system/mattermost_gitlab.service`
 
 ```
 [Unit]
@@ -143,7 +143,7 @@ User=mattermost
 Group=mattermost
 ExecStart=/usr/local/bin/mattermost_gitlab http://mattermost/hooks/hook-id
 PrivateTmp=yes
-WorkingDirectory=/opt/mattermost
+WorkingDirectory=/opt/mattermost #for omnibus installations, use /opt/gitlab/embedded/service/mattermost
 Restart=always
 RestartSec=30
 LimitNOFILE=49152
@@ -153,8 +153,8 @@ WantedBy=multi-user.target
 ```
 
 - `systemctl daemon-reload`
-- `systemctl enable mattermost`
-- `systemctl start mattermost`
+- `systemctl enable mattermost_gitlab`
+- `systemctl start mattermost_gitlab`
 
 3. **Connect your project to your GitLab account for outgoing webhooks**
  1. Log in to GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the left side of the project screen, click on **Settings** > **Web Hooks**. In the **URL** field enter `http://<your-mattermost-integration-URL>/new_event` (notice extra `new_event` URL argument). On this address the integration service will be receiving the events from your GitLab project. Make sure your URL has a leading `http://` or `https://`.

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -82,7 +82,7 @@ class PushEvent(BaseEvent):
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
 
-        return text.encode('ascii')
+        return unicode(text)
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -72,14 +72,17 @@ class PushEvent(BaseEvent):
         if self.data['total_commits_count'] > 1:
             description += "s"
 
-        return '%s pushed %s into the `%s` branch for project [%s](%s).' % (
+        text = '%s pushed %s into the `%s` branch for project [%s](%s).\n' % (
             self.data['user_name'],
             description,
             self.data['ref'],
             self.data['repository']['name'],
             self.data['repository']['homepage']
         )
-
+        for val in self.data['commits']:
+            text += "[%s](%s)" % (val['message'], val['url'])
+            
+        return text
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -72,17 +72,22 @@ class PushEvent(BaseEvent):
         if self.data['total_commits_count'] > 1:
             description += "s"
 
-        text = '%s pushed %s into the `%s` branch for project [%s](%s).\n' % (
+        suffix = str('')
+        if len(self.data['commits']) > 0:
+            suffix = str('\n')
+
+        text = '%s pushed %s into the `%s` branch for project [%s](%s).%s' % (
             self.data['user_name'],
             description,
             self.data['ref'],
             self.data['repository']['name'],
-            self.data['repository']['homepage']
+            self.data['repository']['homepage'],
+            suffix
         )
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
 
-        return unicode(text)
+        return str(text)
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -82,7 +82,7 @@ class PushEvent(BaseEvent):
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
 
-        return str(text)
+        return text.encode('ascii')
 
 class IssueEvent(BaseEvent):
 

--- a/mattermost_gitlab/event_formatter.py
+++ b/mattermost_gitlab/event_formatter.py
@@ -81,8 +81,8 @@ class PushEvent(BaseEvent):
         )
         for val in self.data['commits']:
             text += "[%s](%s)" % (val['message'], val['url'])
-            
-        return text
+
+        return str(text)
 
 class IssueEvent(BaseEvent):
 

--- a/tests/data/gitlab/push/commit_dev_branch.md
+++ b/tests/data/gitlab/push/commit_dev_branch.md
@@ -1,1 +1,3 @@
 Example User pushed the first commit into the `refs/heads/dev` branch for project [example repository](http://gitlab_url/example_user/example-repository).
+[bump2
+](http://gitlab_url/example_user/example-repository/commit/a0e40a9b8e8bd3ad3acccf64c016244109b15d37)

--- a/tests/data/gitlab/push/commit_master_branch.md
+++ b/tests/data/gitlab/push/commit_master_branch.md
@@ -1,1 +1,3 @@
 Example User pushed 1 commit into the `refs/heads/master` branch for project [example repository](http://gitlab_url/example_user/example-repository).
+[bump
+](http://gitlab_url/example_user/example-repository/commit/bf249e058f87ef90a14be04268efde573c8431e4)

--- a/tests/data/gitlab/push/commit_merge_request.md
+++ b/tests/data/gitlab/push/commit_merge_request.md
@@ -1,1 +1,9 @@
 Example User pushed 2 commits into the `refs/heads/master` branch for project [example repository](http://gitlab_url/example_user/example-repository).
+[bump2
+](http://gitlab_url/example_user/example-repository/commit/a0e40a9b8e8bd3ad3acccf64c016244109b15d37)[Merge branch 'dev' into 'master'
+
+Master
+
+new description
+
+See merge request !1](http://gitlab_url/example_user/example-repository/commit/19df8c9c23daf53ea122ea0834814b846ea92875)


### PR DESCRIPTION
Relevant to issue #23 

**_Corrections made_**
* Not sure if this is a good idea, but I added instruction to do `chown` command and assign ownership of gitlab_mattermost to user mattermost and group mattermost. Assuming this is the best approach, correct me if chmod is the better option or if this should be skipped entirely.
* systemctl commands at bottom did not reference the correct unit name
* `nano` is better suited for all audiences, hands down.
* working directory needs to be different for omnibus installations, otherwise you'll get a very cryptic error message from /opt/var/syslog. (Reference can be found [here](https://bugs.freedesktop.org/show_bug.cgi?id=89864))

```
Dec 12 10:31:35 gitlab systemd[5406]: mattermost_gitlab.service: Failed at step CHDIR spawning /usr/local/bin/mattermost_gitlab: No such file or directory
```