### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git*
+*.swp
+*.egg-info
+*.pyc
+.tox
+.coverage
+htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:16.04
+
+RUN apt -y update && apt -y upgrade
+RUN apt -y install python-pip python-dev build-essential
+RUN pip install virtualenv
+
+RUN mkdir -p /opt/mattermost-integration-gitlab
+COPY . /opt/mattermost-integration-gitlab
+WORKDIR /opt/mattermost-integration-gitlab
+RUN pip install .
+
+
+EXPOSE 5000
+
+CMD /opt/mattermost-integration-gitlab/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ WantedBy=multi-user.target
 - `systemctl enable mattermost_gitlab`
 - `systemctl start mattermost_gitlab`
 
+### Using Docker
+Simply build docker image and run it.
+There are several environment variables that can be used to change behaviour of plugin (see entrypoint.sh)
+
+```bash
+docker build -t mattermost-integration-gitlab .
+docker run -d -E MATTERMOST_WEBHOOK_URL=http://mattermost/hooks/hook-id mattermost-integration-gitlab
+```
+
 
 3. **Connect your project to your GitLab account for outgoing webhooks**
  1. Log in to your GitLab account and open the project from which you want to receive updates and to which you have administrator access. From the settings menu of the project, click on **Webhooks**. In the **URL** field enter `http://<your-mattermost-integration-URL>/new_event` (notice extra `new_event` URL argument). On this address the integration service will be receiving the events from your GitLab project. Make sure your URL has a leading `http://` or `https://`.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+
+PLUGIN_ARGS=
+
+if [ -n "${MATTERMOST_USERNAME}" ]; then
+	PLUGIN_ARGS="${PLUGIN_ARGS} --username ${MATTERMOST_USERNAME}"
+fi
+
+if [ -n "${MATTERMOST_CHANNEL}" ]; then
+	PLUGIN_ARGS="${PLUGIN_ARGS} --channel ${MATTERMOST_CHANNEL}"
+fi
+
+if [ -n "${MATTERMOST_ICON}" ]; then
+	PLUGIN_ARGS="${PLUGIN_ARGS} --icon ${MATTERMOST_ICON}"
+fi
+
+
+EVENTS=( PUSH TAG )
+for POSSIBLE_EVENT in "${EVENTS[@]}"; do
+	ENV_NAME="MATTERMOST_EVENT_${POSSIBLE_EVENT}"
+	eval VALUE=\$${ENV_NAME}
+	if [ -n "${VALUE}" ]; then
+		if [ "${VALUE}" == "1" -o "${VALUE}" == "yes" -o "${VALUE}" == "y" ]; then
+			PLUGIN_ARGS="${PLUGIN_ARGS} --${POSSIBLE_EVENT,,}"
+		fi
+	fi
+done
+
+NEGATIVE_EVENTS=( ISSUE COMMENT MERGE-REQUEST CI )
+for POSSIBLE_EVENT in "${NEGATIVE_EVENTS[@]}"; do
+	ENV_NAME="MATTERMOST_EVENT_${POSSIBLE_EVENT}"
+	eval VALUE=\$${ENV_NAME}
+	if [ -n "${VALUE}" ]; then
+		if [ "${VALUE}" == "0" -o "${VALUE}" == "n" -o "${VALUE}" == "no" ]; then
+			PLUGIN_ARGS="${PLUGIN_ARGS} --no-${POSSIBLE_EVENT,,}"
+		fi
+	fi
+done
+
+if [ -z "${MATTERMOST_WEBHOOK_URL}" ]; then
+	echo "Missing Mattermost WEBHOOK url !" >&2
+	exit 1
+fi
+
+
+if [ ! -x "/usr/local/bin/mattermost_gitlab" ]; then
+	echo "Missing application executable !" >&2
+	exit 1
+fi
+
+echo "Starting: "
+echo "/usr/local/bin/mattermost_gitlab ${PLUGIN_ARGS} '${MATTERMOST_WEBHOOK_URL}'"
+/usr/local/bin/mattermost_gitlab ${PLUGIN_ARGS} "${MATTERMOST_WEBHOOK_URL}"


### PR DESCRIPTION
Added Dockerfile for building image for docker.
Entrypoint supports almost all parameters of plugin (except Host and Port which are unnecessary in docker)